### PR TITLE
Allow retrieve of separate structs in same directory

### DIFF
--- a/Sources/Disk+Codable.swift
+++ b/Sources/Disk+Codable.swift
@@ -155,12 +155,19 @@ public extension Disk {
             
             // If url points to a directory, iterate the files inside the directory
             if let fileUrls = try? FileManager.default.contentsOfDirectory(at: url, includingPropertiesForKeys: nil, options: []) {
+                let sortedFileUrls = fileUrls.sorted(by: { (url1, url2) -> Bool in
+                    if let fileNameInt1 = fileNameInt(url1), let fileNameInt2 = fileNameInt(url2) {
+                        return fileNameInt1 <= fileNameInt2
+                    }
+                    return true
+                })
+                
                 var objects = [T]()
                 
-                for i in 0..<fileUrls.count {
-                    let fileUrl = fileUrls[i]
-                    let data = try Data(contentsOf: fileUrl)
-                    if let value = try? decoder.decode(T.self, from: data) {
+                for i in 0..<sortedFileUrls.count {
+                    let fileUrl = sortedFileUrls[i]
+                    if let data = try? Data(contentsOf: fileUrl),
+                        let value = try? decoder.decode(T.self, from: data) {
                         objects.append(value)
                     }
                 }

--- a/Sources/Disk+Codable.swift
+++ b/Sources/Disk+Codable.swift
@@ -128,7 +128,7 @@ public extension Disk {
     /// - Parameters:
     ///   - path: path of the file holding desired data
     ///   - directory: user directory to retrieve the file from
-    ///   - type: struct type (i.e. Message.self or [Message].self)
+    ///   - type: struct type (i.e. Message.self)
     ///   - decoder: custom JSONDecoder to decode existing values
     /// - Returns: decoded structs of data
     /// - Throws: Error if there were any issues retrieving the data or decoding it to the specified type
@@ -146,6 +146,15 @@ public extension Disk {
         }
     }
     
+    /// Retrieve and decode an array of structs from a file or directory on disk
+    ///
+    /// - Parameters:
+    ///   - path: path of the file or directory holding desired data
+    ///   - directory: user directory to retrieve the file from
+    ///   - type: struct type (i.e. [Message].self)
+    ///   - decoder: custom JSONDecoder to decode existing values
+    /// - Returns: decoded array with structs of data
+    /// - Throws: Error if there were any issues retrieving the data or decoding it to the specified type
     static func retrieve<T: Decodable>(_ path: String, from directory: Directory, as type: [T].Type, decoder: JSONDecoder = JSONDecoder()) throws -> [T] {
         if path.hasSuffix("/") {
             throw createInvalidFileNameForStructsError()

--- a/Tests/DiskTests.swift
+++ b/Tests/DiskTests.swift
@@ -86,6 +86,19 @@ class DiskTests: XCTestCase {
             print("Messages were saved as \(messagesUrl.absoluteString)")
             let retrievedMessages = try Disk.retrieve("messages.json", from: .documents, as: [Message].self)
             XCTAssert(messages == retrievedMessages)
+            
+            // Separate structs in same folder
+            try messages.enumerated().forEach({ (index, message) in
+                try Disk.save(message, to: .documents, as: "Messages/\(index).json")
+            })
+            for i in 0..<messages.count {
+                XCTAssert(Disk.exists("Messages/\(i).json", in: .documents))
+            }
+            let messagesInFolderUrl = try Disk.url(for: "Messages", in: .documents)
+            print("Messages were saved in folder \(messagesInFolderUrl.absoluteString)")
+            let retrievedMessagesInFolder = try Disk.retrieve("Messages", from: .documents, as: [Message].self)
+            XCTAssertEqual(messages, retrievedMessagesInFolder)
+            
         } catch {
             fatalError(convertErrorToString(error))
         }


### PR DESCRIPTION
I added the ability to retrieve an array of structs from a directory, where every struct was saved into a separate file (similar to retrieve of `[UIImage]` and `[Data]`).
If the `path` in `retrieve()` points to a directory and the `type` is `[T]`, retrieve will iterate over the files inside the directory and tries to decode every file as `T`.
If the `path` points to a file, the function is the same as before.

I am not sure if this is the most intuitive implementation for the given problem.
The are some cases which are not covered in my implementation, e.g. multiple files with arrays inside the same directory would be ignored.

I would be happy about feedback!