### PR TITLE
We no longer catch an error just to throw it again.

### DIFF
--- a/Sources/Disk+InternalHelpers.swift
+++ b/Sources/Disk+InternalHelpers.swift
@@ -100,20 +100,16 @@ extension Disk {
     
     /// Find an existing file's URL or throw an error if it doesn't exist
     static func getExistingFileURL(for path: String?, in directory: Directory) throws -> URL {
-        do {
-            let url = try createURL(for: path, in: directory)
-            if FileManager.default.fileExists(atPath: url.path) {
-                return url
-            }
+        let url: URL = try createURL(for: path, in: directory)
+        guard FileManager.default.fileExists(atPath: url.path) else {
             throw createError(
                 .noFileFound,
                 description: "Could not find an existing file or folder at \(url.path).",
                 failureReason: "There is no existing file or folder at \(url.path)",
                 recoverySuggestion: "Check if a file or folder exists before trying to commit an operation on it."
             )
-        } catch {
-            throw error
         }
+        return url
     }
     
     /// Convert a user generated name to a valid file name


### PR DESCRIPTION
The line `let url = try createURL(for: path, in: directory)` was in a try catch block, such that if an error was thrown inside `createURL(...)`, it would be caught in the `catch` block, only to be thrown again.

The same issue was the case for the error thrown if `FileManager.default.fileExists(atPath: url.path)` returned true. It would throw the error, then catch it, then throw it again.

Seeing how there was no extra logic that was performed by the catch block, there was no reason to have that catch block.

This update makes changes so that the redundant catch and throw is avoided.