### PR TITLE
SPM & Xcode 11

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,9 @@ import PackageDescription
 let package = Package(
     name: "Disk",
     platforms: [.iOS(.v9)],
+    products: [
+        .library(name: "Disk", targets: ["Disk"])
+    ],
     targets: [
         .target(
             name: "Disk",

--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,20 @@
+// swift-tools-version:5.1
 import PackageDescription
 
 let package = Package(
     name: "Disk",
-    exclude: ["DiskExample", "Tests"]
+    platforms: [.iOS(.v9)],
+    targets: [
+        .target(
+            name: "Disk",
+            path: "Sources",
+            exclude: ["DiskExample"]
+        ),
+        .testTarget(
+            name: "DiskTests",
+            dependencies: ["Disk"],
+            path: "Tests",
+            exclude:  ["DiskExample"]
+        )
+    ]
 )

--- a/Sources/Disk+UIImage.swift
+++ b/Sources/Disk+UIImage.swift
@@ -21,6 +21,7 @@
 // THE SOFTWARE.
 
 import Foundation
+import UIKit
 
 public extension Disk {
     /// Save image to disk

--- a/Sources/Disk+[UIImage].swift
+++ b/Sources/Disk+[UIImage].swift
@@ -21,6 +21,7 @@
 // THE SOFTWARE.
 
 import Foundation
+import UIKit
 
 public extension Disk {
     /// Save an array of images to disk


### PR DESCRIPTION
To use Disk as SPM dependency in Xcode 11 we need to modify Package.swift file a bit and add missing UIKit imports.