### PR TITLE
Add Privacy Manifest file

### DIFF
--- a/Disk.podspec
+++ b/Disk.podspec
@@ -13,4 +13,5 @@ Pod::Spec.new do |s|
   s.platform     = :ios, "9.0"
   s.source       = { :git => "https://github.com/saoudrizwan/Disk.git", :tag => "#{s.version}" }
   s.source_files  = "Sources/**/*.{h,m,swift}"
+  s.resource_bundles = {"Disk" => ["Sources/PrivacyInfo.xcprivacy"]}
 end

--- a/Disk.xcodeproj/project.pbxproj
+++ b/Disk.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		10F3C7041F23D9C9006D42EF /* Disk+Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10F3C7031F23D9C9006D42EF /* Disk+Data.swift */; };
 		10F3C7061F23D9E0006D42EF /* Disk+[Data].swift in Sources */ = {isa = PBXBuildFile; fileRef = 10F3C7051F23D9E0006D42EF /* Disk+[Data].swift */; };
 		10F3C7081F23DAF2006D42EF /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10F3C7071F23DAF2006D42EF /* Message.swift */; };
+		7948F3CA2B8DD848006F61A7 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 7948F3C92B8DD848006F61A7 /* PrivacyInfo.xcprivacy */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -55,6 +56,7 @@
 		10F3C7031F23D9C9006D42EF /* Disk+Data.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Disk+Data.swift"; sourceTree = "<group>"; };
 		10F3C7051F23D9E0006D42EF /* Disk+[Data].swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Disk+[Data].swift"; sourceTree = "<group>"; };
 		10F3C7071F23DAF2006D42EF /* Message.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
+		7948F3C92B8DD848006F61A7 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -109,6 +111,7 @@
 				10F3C7011F23D9C1006D42EF /* Disk+[UIImage].swift */,
 				10F3C7031F23D9C9006D42EF /* Disk+Data.swift */,
 				10F3C7051F23D9E0006D42EF /* Disk+[Data].swift */,
+				7948F3C92B8DD848006F61A7 /* PrivacyInfo.xcprivacy */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -219,6 +222,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7948F3CA2B8DD848006F61A7 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/PrivacyInfo.xcprivacy
+++ b/Sources/PrivacyInfo.xcprivacy
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>E174.1</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+</dict>
+</plist>


### PR DESCRIPTION
Hello

This PR resolves https://github.com/saoudrizwan/Disk/issues/94

### 1. Added xcprivacy
- I thought that Disk uses following required reason API, so I selected `Disk Space` for `NSPrivacyAccessedAPIType`
 	- `.volumeAvailableCapacityKey`
	- `.volumeAvailableCapacityForImportantUsageKey`
	- `.volumeAvailableCapacityForOpportunisticUsageKey`
	- `.volumeTotalCapacityKey`
- I selected `E174.1` for `NSPrivacyAccessedAPITypeReasons`. Change if not correct.

### 2. Append privacy file to CocoaPods bundle
- I applied privacyinfo as resource_bundles

Thanks